### PR TITLE
Fix rounding issue with uneven voxel model sizes leading undesired to offsets for models.

### DIFF
--- a/Source/glTFRuntimeVox/Private/glTFRuntimeVoxFunctionLibrary.cpp
+++ b/Source/glTFRuntimeVox/Private/glTFRuntimeVoxFunctionLibrary.cpp
@@ -130,9 +130,9 @@ namespace glTFRuntimeVox
 	void AddVoxelInstance(const uint32 X, const uint32 Y, const uint32 Z, const uint32 Color, const TArray<uint32>& Palette, const FglTFRuntimeVoxConfig& VoxConfig, const FUintVector Size, FTransform& Transform, FLinearColor& LinearColor)
 	{
 		const float Scale = VoxConfig.VoxelSize;
-		float XScaled = Y * Scale - (Size.Y * 0.5 * Scale) + (Y * VoxConfig.Padding);
-		float YScaled = X * Scale - (Size.X * 0.5 * Scale) + (X * VoxConfig.Padding);
-		float ZScaled = Z * Scale - (Size.Z * 0.5 * Scale) + (Z * VoxConfig.Padding);
+		float XScaled = Y * Scale - (FMath::FloorToInt(Size.Y * 0.5) * Scale) + (Y * VoxConfig.Padding);
+		float YScaled = X * Scale - (FMath::FloorToInt(Size.X * 0.5) * Scale) + (X * VoxConfig.Padding);
+		float ZScaled = Z * Scale - (FMath::FloorToInt(Size.Z * 0.5) * Scale) + (Z * VoxConfig.Padding);
 
 		Transform.SetLocation(FVector(XScaled, YScaled, ZScaled));
 
@@ -142,9 +142,9 @@ namespace glTFRuntimeVox
 	void AddVoxel(FglTFRuntimePrimitive& Primitive, const uint32 X, const uint32 Y, const uint32 Z, const uint32 Color, const TArray<uint32>& Palette, const FglTFRuntimeVoxConfig& VoxConfig, const FUintVector Size)
 	{
 		const float Scale = VoxConfig.VoxelSize;
-		float XScaled = Y * Scale - (Size.Y * 0.5 * Scale) + (Y * VoxConfig.Padding);
-		float YScaled = X * Scale - (Size.X * 0.5 * Scale) + (X * VoxConfig.Padding);
-		float ZScaled = Z * Scale - (Size.Z * 0.5 * Scale) + (Z * VoxConfig.Padding);
+		float XScaled = Y * Scale - (FMath::FloorToInt(Size.Y * 0.5) * Scale) + (Y * VoxConfig.Padding);
+		float YScaled = X * Scale - (FMath::FloorToInt(Size.X * 0.5) * Scale) + (X * VoxConfig.Padding);
+		float ZScaled = Z * Scale - (FMath::FloorToInt(Size.Z * 0.5) * Scale) + (Z * VoxConfig.Padding);
 
 		const int32 Base = Primitive.Positions.Num();
 


### PR DESCRIPTION
In case a vox model is uneven in a axis size there is an undesired offset due to rounding issues.
This PR is about to fix this rounding issue so that this case is handled correctly.
See images below.

Before:
![image](https://github.com/user-attachments/assets/0eaa4979-b808-496f-8380-b90b034909ba)


After:
![image](https://github.com/user-attachments/assets/1021a6c8-2b74-4030-ad17-34b4dece3d4a)
